### PR TITLE
Fix unavailable urls

### DIFF
--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -427,7 +427,7 @@
 * [CSS3 Tutorial 《CSS3 教程》](https://github.com/waylau/css3-tutorial)
 * [CSS参考手册](http://css.doyoe.com)
 * [Emmet 文档](http://yanxyz.github.io/emmet-docs/)
-* [HTML5 教程](http://www.w3school.com.cn/html5/)
+* [HTML5 教程](http://www.w3school.com.cn/html5/index.asp)
 * [HTML和CSS编码规范](http://codeguide.bootcss.com)
 * [Sass Guidelines 中文](http://sass-guidelin.es/zh/)
 * [前端代码规范](http://alloyteam.github.io/CodeGuide/) - 腾讯AlloyTeam团队
@@ -584,9 +584,7 @@
 
 ### Markdown
 
-* [Markdown 快速入门](http://wowubuntu.com/markdown/basic.html)
 * [Markdown 简明教程](http://www.jianshu.com/p/7bd23251da0a)
-* [Markdown 语法说明](http://wowubuntu.com/markdown/)
 * [献给写作者的 Markdown 新手指南](http://www.jianshu.com/p/q81RER)
 
 


### PR DESCRIPTION
# What does this PR do?

1. Remove 2 unavailable links: 《Markdown 快速入门》 (http://wowubuntu.com/markdown/basic.html)  And 《Markdown 语法说明》
2. Change [HTML5 教程] link from http://www.w3school.com.cn/html5 to http://www.w3school.com.cn/html5/index.asp